### PR TITLE
FIX: readme typos and missing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,21 @@
 # ORBITAL
 ![Orbital Logo](assets/orbital_logo_600px.png)
 
-_Observable Reducer for Behavior, Interaction, Transictions Actions & Logic_
+_Observable Reducer for Behavior, Interaction, Transition Actions & Logic_
 
 The idea behind ORBITAL is to provide a centralized and reliable way to manage global states with predictable outcomes.
 
 ## What problem does it solve?
-Some python applications have complex and dynamic states, such as reactive systems (like those with UI frameworks), automation and robotics software, games, simulations and others. At those systems, multiple modules should react to events, should be able to alter the state and read from the same global state in a reliable and predictable way.
+Some Python applications have complex and dynamic states, such as reactive systems (like those with UI frameworks), automation and robotics software, games, simulations, and others. In these systems, multiple modules should react to events, be able to alter the state, and read from the same global state in a reliable and predictable way
 
 # Status
-Currently, ORBITAL is a Work in Progress, being developed whenever I have time. At a future point, where the core of the library is stable, I plan to add some guidelines on how to contribute to the project.
+Currently, ORBITAL is a work in progress, being developed whenever I have time. At a future point, when the core of the library is stable, I plan to add guidelines on how to contribute to the project.
 
 ## Roadmap:
 The `Issues` section currently provides a rough roadmap of what is planned for the next development steps.
-A documentation should be provided in github pages when a basic api of the library is established.
+Documentation will be provided on GitHub Pages when a basic API for the library is established.
+
+# License
+This project does not currently have an open-source license.
+Use, distribution, or modification of this code is not permitted without prior written consent from the author.
+Please contact the repository owner before using or altering any part of this project.


### PR DESCRIPTION
This pull request updates the `README.md` to improve clarity, fix typos, and add important information about licensing. The most significant change is the addition of a new section clarifying the project's license status and usage restrictions.

Documentation improvements:

* Fixed typos and improved phrasing for better readability and professionalism throughout the `README.md`.
* Clarified the description of the project's purpose and the types of applications it targets.
* Updated the roadmap section to specify that documentation will be provided on GitHub Pages once a basic API is established.

License and usage information:

* Added a new license section stating that the project does not currently have an open-source license and that usage, distribution, or modification is not permitted without prior written consent from the author. Instructions for contacting the repository owner are also provided.